### PR TITLE
feat: adds `vue/padding-line-between-blocks` rule

### DIFF
--- a/packages/vue/index.js
+++ b/packages/vue/index.js
@@ -132,5 +132,6 @@ module.exports = defineConfig({
         order: ["script", "template", "style"],
       },
     ],
+    "vue/padding-line-between-blocks": ["error", "always"],
   },
 });


### PR DESCRIPTION
Introduces new rule: [padding-line-between-blocks](https://eslint.vuejs.org/rules/padding-line-between-blocks.html)