### PR TITLE
feat(vue): introduce vue/define-props-declaration as a warning

### DIFF
--- a/packages/vue/index.js
+++ b/packages/vue/index.js
@@ -140,5 +140,6 @@ module.exports = defineConfig({
         ignoreIncludesComment: false,
       },
     ],
+    'vue/define-props-declaration': ['warn', 'type-based'],
   },
 });


### PR DESCRIPTION
Part of #8 

I am gonna keep the issue open until we can turn this into an error.
At the moment we still have more than 100 warnings.