### PR TITLE
fix: use correct @stylistic/ prefix for rule overrides

### DIFF
--- a/fixtures/input/yaml.yaml
+++ b/fixtures/input/yaml.yaml
@@ -1,3 +1,4 @@
+# Configuration for the test fixture (used by eslint-config)
 name:   test
 version: "1.0.0"
 description:    A test YAML file

--- a/fixtures/output/all/yaml.yaml
+++ b/fixtures/output/all/yaml.yaml
@@ -1,3 +1,4 @@
+# Configuration for the test fixture (used by eslint-config)
 name: test
 version: 1.0.0
 description: A test YAML file

--- a/fixtures/output/js/yaml.yaml
+++ b/fixtures/output/js/yaml.yaml
@@ -1,3 +1,4 @@
+# Configuration for the test fixture (used by eslint-config)
 name: test
 version: 1.0.0
 description: A test YAML file

--- a/fixtures/output/less-opinionated/yaml.yaml
+++ b/fixtures/output/less-opinionated/yaml.yaml
@@ -1,3 +1,4 @@
+# Configuration for the test fixture (used by eslint-config)
 name: test
 version: 1.0.0
 description: A test YAML file

--- a/fixtures/output/no-markdown-with-formatters/yaml.yaml
+++ b/fixtures/output/no-markdown-with-formatters/yaml.yaml
@@ -1,3 +1,4 @@
+# Configuration for the test fixture (used by eslint-config)
 name: test
 version: 1.0.0
 description: A test YAML file

--- a/fixtures/output/no-style/yaml.yaml
+++ b/fixtures/output/no-style/yaml.yaml
@@ -1,3 +1,4 @@
+# Configuration for the test fixture (used by eslint-config)
 name:   test
 version: 1.0.0
 description:    A test YAML file

--- a/fixtures/output/tab-double-quotes/yaml.yaml
+++ b/fixtures/output/tab-double-quotes/yaml.yaml
@@ -1,3 +1,4 @@
+# Configuration for the test fixture (used by eslint-config)
 name: test
 version: 1.0.0
 description: A test YAML file

--- a/fixtures/output/ts-strict/yaml.yaml
+++ b/fixtures/output/ts-strict/yaml.yaml
@@ -1,3 +1,4 @@
+# Configuration for the test fixture (used by eslint-config)
 name: test
 version: 1.0.0
 description: A test YAML file

--- a/fixtures/output/with-formatters/yaml.yaml
+++ b/fixtures/output/with-formatters/yaml.yaml
@@ -1,3 +1,4 @@
+# Configuration for the test fixture (used by eslint-config)
 name: test
 version: 1.0.0
 description: A test YAML file

--- a/fixtures/output/with-regexp/yaml.yaml
+++ b/fixtures/output/with-regexp/yaml.yaml
@@ -1,3 +1,4 @@
+# Configuration for the test fixture (used by eslint-config)
 name: test
 version: 1.0.0
 description: A test YAML file

--- a/src/configs/markdown.ts
+++ b/src/configs/markdown.ts
@@ -54,8 +54,10 @@ export async function markdown(
       },
       name: 'rotki/markdown/disables',
       rules: {
-        '@typescript-eslint/consistent-type-imports': 'off',
+        '@stylistic/comma-dangle': 'off',
 
+        '@stylistic/eol-last': 'off',
+        '@typescript-eslint/consistent-type-imports': 'off',
         '@typescript-eslint/explicit-function-return-type': 'off',
         '@typescript-eslint/no-namespace': 'off',
         '@typescript-eslint/no-redeclare': 'off',
@@ -63,22 +65,20 @@ export async function markdown(
         '@typescript-eslint/no-unused-expressions': 'off',
         '@typescript-eslint/no-unused-vars': 'off',
         '@typescript-eslint/no-use-before-define': 'off',
+
         'import/newline-after-import': 'off',
         'no-alert': 'off',
 
         'no-console': 'off',
         'no-labels': 'off',
-
         'no-lone-blocks': 'off',
         'no-restricted-syntax': 'off',
         'no-undef': 'off',
         'no-unused-expressions': 'off',
         'no-unused-labels': 'off',
         'no-unused-vars': 'off',
-        'node/prefer-global/process': 'off',
-        'style/comma-dangle': 'off',
 
-        'style/eol-last': 'off',
+        'node/prefer-global/process': 'off',
         'unicode-bom': 'off',
         'unused-imports/no-unused-imports': 'off',
 

--- a/src/configs/yaml.ts
+++ b/src/configs/yaml.ts
@@ -40,7 +40,7 @@ export async function yaml(
       },
       name: 'rotki/yaml/rules',
       rules: {
-        'style/spaced-comment': 'off',
+        '@stylistic/spaced-comment': 'off',
 
         'yaml/block-mapping': 'error',
         'yaml/block-sequence': 'error',

--- a/test/__snapshots__/factory/default.snap.json
+++ b/test/__snapshots__/factory/default.snap.json
@@ -1439,8 +1439,8 @@
     },
     "name": "rotki/yaml/rules",
     "rules": {
+      "@stylistic/spaced-comment": "off",
       "max-lines": "off",
-      "style/spaced-comment": "off",
       "yaml/block-mapping": "error",
       "yaml/block-mapping-question-indicator-newline": "error",
       "yaml/block-sequence": "error",
@@ -1508,6 +1508,8 @@
     },
     "name": "rotki/markdown/disables",
     "rules": {
+      "@stylistic/comma-dangle": "off",
+      "@stylistic/eol-last": "off",
       "@typescript-eslint/consistent-type-imports": "off",
       "@typescript-eslint/explicit-function-return-type": "off",
       "@typescript-eslint/no-namespace": "off",
@@ -1527,8 +1529,6 @@
       "no-unused-labels": "off",
       "no-unused-vars": "off",
       "node/prefer-global/process": "off",
-      "style/comma-dangle": "off",
-      "style/eol-last": "off",
       "unicode-bom": "off",
       "unused-imports/no-unused-imports": "off",
       "unused-imports/no-unused-vars": "off"

--- a/test/__snapshots__/factory/full-on.snap.json
+++ b/test/__snapshots__/factory/full-on.snap.json
@@ -2158,8 +2158,8 @@
     },
     "name": "rotki/yaml/rules",
     "rules": {
+      "@stylistic/spaced-comment": "off",
       "max-lines": "off",
-      "style/spaced-comment": "off",
       "yaml/block-mapping": "error",
       "yaml/block-mapping-question-indicator-newline": "error",
       "yaml/block-sequence": "error",
@@ -2228,6 +2228,8 @@
     },
     "name": "rotki/markdown/disables",
     "rules": {
+      "@stylistic/comma-dangle": "off",
+      "@stylistic/eol-last": "off",
       "@typescript-eslint/consistent-type-imports": "off",
       "@typescript-eslint/explicit-function-return-type": "off",
       "@typescript-eslint/no-namespace": "off",
@@ -2247,8 +2249,6 @@
       "no-unused-labels": "off",
       "no-unused-vars": "off",
       "node/prefer-global/process": "off",
-      "style/comma-dangle": "off",
-      "style/eol-last": "off",
       "unicode-bom": "off",
       "unused-imports/no-unused-imports": "off",
       "unused-imports/no-unused-vars": "off"

--- a/test/__snapshots__/factory/in-editor.snap.json
+++ b/test/__snapshots__/factory/in-editor.snap.json
@@ -1439,8 +1439,8 @@
     },
     "name": "rotki/yaml/rules",
     "rules": {
+      "@stylistic/spaced-comment": "off",
       "max-lines": "off",
-      "style/spaced-comment": "off",
       "yaml/block-mapping": "error",
       "yaml/block-mapping-question-indicator-newline": "error",
       "yaml/block-sequence": "error",
@@ -1508,6 +1508,8 @@
     },
     "name": "rotki/markdown/disables",
     "rules": {
+      "@stylistic/comma-dangle": "off",
+      "@stylistic/eol-last": "off",
       "@typescript-eslint/consistent-type-imports": "off",
       "@typescript-eslint/explicit-function-return-type": "off",
       "@typescript-eslint/no-namespace": "off",
@@ -1527,8 +1529,6 @@
       "no-unused-labels": "off",
       "no-unused-vars": "off",
       "node/prefer-global/process": "off",
-      "style/comma-dangle": "off",
-      "style/eol-last": "off",
       "unicode-bom": "off",
       "unused-imports/no-unused-imports": "off",
       "unused-imports/no-unused-vars": "off"

--- a/test/__snapshots__/factory/javascript-vue.snap.json
+++ b/test/__snapshots__/factory/javascript-vue.snap.json
@@ -1802,8 +1802,8 @@
     },
     "name": "rotki/yaml/rules",
     "rules": {
+      "@stylistic/spaced-comment": "off",
       "max-lines": "off",
-      "style/spaced-comment": "off",
       "yaml/block-mapping": "error",
       "yaml/block-mapping-question-indicator-newline": "error",
       "yaml/block-sequence": "error",
@@ -1872,6 +1872,8 @@
     },
     "name": "rotki/markdown/disables",
     "rules": {
+      "@stylistic/comma-dangle": "off",
+      "@stylistic/eol-last": "off",
       "@typescript-eslint/consistent-type-imports": "off",
       "@typescript-eslint/explicit-function-return-type": "off",
       "@typescript-eslint/no-namespace": "off",
@@ -1891,8 +1893,6 @@
       "no-unused-labels": "off",
       "no-unused-vars": "off",
       "node/prefer-global/process": "off",
-      "style/comma-dangle": "off",
-      "style/eol-last": "off",
       "unicode-bom": "off",
       "unused-imports/no-unused-imports": "off",
       "unused-imports/no-unused-vars": "off"

--- a/test/__snapshots__/factory/less-opinionated.snap.json
+++ b/test/__snapshots__/factory/less-opinionated.snap.json
@@ -1439,8 +1439,8 @@
     },
     "name": "rotki/yaml/rules",
     "rules": {
+      "@stylistic/spaced-comment": "off",
       "max-lines": "off",
-      "style/spaced-comment": "off",
       "yaml/block-mapping": "error",
       "yaml/block-mapping-question-indicator-newline": "error",
       "yaml/block-sequence": "error",
@@ -1508,6 +1508,8 @@
     },
     "name": "rotki/markdown/disables",
     "rules": {
+      "@stylistic/comma-dangle": "off",
+      "@stylistic/eol-last": "off",
       "@typescript-eslint/consistent-type-imports": "off",
       "@typescript-eslint/explicit-function-return-type": "off",
       "@typescript-eslint/no-namespace": "off",
@@ -1527,8 +1529,6 @@
       "no-unused-labels": "off",
       "no-unused-vars": "off",
       "node/prefer-global/process": "off",
-      "style/comma-dangle": "off",
-      "style/eol-last": "off",
       "unicode-bom": "off",
       "unused-imports/no-unused-imports": "off",
       "unused-imports/no-unused-vars": "off"

--- a/test/factory-snap.test.ts
+++ b/test/factory-snap.test.ts
@@ -97,6 +97,20 @@ describe('factory-snap', () => {
     await run('javascript-vue', configs);
   });
 
+  it('yaml config disables @stylistic/spaced-comment', async () => {
+    const configs = await rotki({
+      vue: false,
+      pnpm: false,
+    });
+
+    const yamlRulesConfig = configs.find(
+      (config: Record<string, any>) => config.name === 'rotki/yaml/rules',
+    ) as Record<string, any> | undefined;
+
+    expect(yamlRulesConfig).toBeDefined();
+    expect(yamlRulesConfig!.rules['@stylistic/spaced-comment']).toBe('off');
+  });
+
   it('in-editor', async () => {
     const configs = await rotki({
       isInEditor: true,


### PR DESCRIPTION
## Summary

- Replace invalid `style/` prefix with `@stylistic/` in YAML and markdown configs
- `style/spaced-comment` in `yaml.ts`, `style/comma-dangle` and `style/eol-last` in `markdown.ts` were no-ops because no `style` plugin is registered — the actual plugin is `@stylistic`
- Add test verifying `@stylistic/spaced-comment` is disabled for YAML files
- Add YAML comment to fixture input to catch regressions

## Test plan

- [x] New unit test: `yaml config disables @stylistic/spaced-comment`
- [x] Fixture test confirms YAML comments are no longer mangled by the rule
- [x] All 17 tests pass

Closes #80