### PR TITLE
chore: raise vue/max-props limit to 8

### DIFF
--- a/src/configs/vue.ts
+++ b/src/configs/vue.ts
@@ -63,7 +63,7 @@ export async function vue(
         svg: 'always',
       },
     ],
-    'vue/max-props': ['warn', { maxProps: 6 }],
+    'vue/max-props': ['warn', { maxProps: 8 }],
     'vue/max-template-depth': ['warn', { maxDepth: 8 }],
     'vue/multiline-html-element-content-newline': [
       'error',

--- a/test/__snapshots__/factory/full-on.snap.json
+++ b/test/__snapshots__/factory/full-on.snap.json
@@ -1471,7 +1471,7 @@
       "vue/max-props": [
         "warn",
         {
-          "maxProps": 6
+          "maxProps": 8
         }
       ],
       "vue/max-template-depth": [

--- a/test/__snapshots__/factory/javascript-vue.snap.json
+++ b/test/__snapshots__/factory/javascript-vue.snap.json
@@ -1248,7 +1248,7 @@
       "vue/max-props": [
         "warn",
         {
-          "maxProps": 6
+          "maxProps": 8
         }
       ],
       "vue/max-template-depth": [


### PR DESCRIPTION
Raises the `vue/max-props` warning threshold from 6 to 8 props.

The previous limit of 6 was triggering warnings on components that legitimately need more props. 8 is a more practical ceiling while still flagging components that have grown too large.